### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-vcard/security/code-scanning/1](https://github.com/RumenDamyanov/php-vcard/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key at the workflow level (top-level, just below `name:` and before `on:`) to restrict the `GITHUB_TOKEN` to read-only access to repository contents. This is the minimal permission required for the workflow to check out code and run tests. No steps in the workflow require write access. The best way to implement this is to add:

```yaml
permissions:
  contents: read
```

immediately after the `name: Tests` line (line 1), before the `on:` block. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
